### PR TITLE
Fix authentication header name

### DIFF
--- a/unsplasharp/Source/UnsplasharpClient.cs
+++ b/unsplasharp/Source/UnsplasharpClient.cs
@@ -994,7 +994,7 @@ namespace Unsplasharp {
         private async Task<string> Fetch(string url) {
             HttpClient http = new HttpClient();
             http.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("client_id", ApplicationId);
+                new AuthenticationHeaderValue("Client-ID", ApplicationId);
             HttpResponseMessage response = null;
 
             try {


### PR DESCRIPTION
Correct name is Client-ID (appears to be case sensitive as well). According to the **docs** `client_id` is only used when passing it as a query param. `Client-ID` is used for authentication header.

**docs**: https://unsplash.com/documentation#public-authentication

This fixes issue #6 